### PR TITLE
Format date fields for buses and drivers tables

### DIFF
--- a/web/src/components/common/detail/detailConfigs.js
+++ b/web/src/components/common/detail/detailConfigs.js
@@ -82,20 +82,11 @@ export const busConfig = {
       key: "data_ultima_manutencao",
       label: "Última Manutenção",
       icon: "bi bi-wrench",
-      formatter: (value) => value ? new Date(value).toLocaleDateString('pt-BR') : "Não informado"
     },
     {
       key: "data_proxima_manutencao",
       label: "Próxima Manutenção",
       icon: "bi bi-calendar-plus",
-      formatter: (value) => {
-        if (!value) return "Não informado";
-        const date = new Date(value);
-        const today = new Date();
-        const isOverdue = date < today;
-        const formattedDate = date.toLocaleDateString('pt-BR');
-        return isOverdue ? `${formattedDate} (ATRASADA)` : formattedDate;
-      }
     }
   ]
 };
@@ -233,14 +224,6 @@ export const driverConfig = {
       key: "cnh_validade",
       label: "Validade da CNH",
       icon: "bi bi-calendar-event",
-      formatter: (value) => {
-        if (!value) return "Não informado";
-        const date = new Date(value);
-        const today = new Date();
-        const isExpired = date <= today;
-        const formattedDate = date.toLocaleDateString('pt-BR');
-        return isExpired ? `${formattedDate} (VENCIDA)` : formattedDate;
-      }
     },
     {
       key: "telefone",

--- a/web/src/pages/BusesPage.jsx
+++ b/web/src/pages/BusesPage.jsx
@@ -15,6 +15,9 @@ const tableHeaders = [
   { id: "marca", label: "Marca", sortable: true },
   { id: "ano_fabricacao", label: "Ano", sortable: true },
   { id: "capacidade", label: "Capacidade", sortable: true },
+  { id: "data_ultima_manutencao", label: "Última Manutenção", sortable: true },
+  { id: "data_proxima_manutencao", label: "Próxima Manutenção", sortable: true },
+  { id: "quilometragem", label: "Quilometragem", sortable: true },
   { id: "status", label: "Status", sortable: true },
 ];
 
@@ -39,10 +42,21 @@ function Buses({ pageFunctions }) {
       // Adaptar os dados do servidor para o formato esperado pelo frontend
       let busesData = [];
       if (response && response.data && Array.isArray(response.data)) {
-        busesData = response.data.map(bus => ({
-          ...bus, 
-          status: bus.status_nome 
-        }));
+        busesData = response.data.map(bus => {
+          // Função para formatar a data para DD/MM/AAAA
+          const formatDate = (dateString) => {
+            if (!dateString) return "N/A";
+            const date = new Date(dateString);
+            return date.toLocaleDateString('pt-BR');
+          };
+
+          return {
+            ...bus,
+            status: bus.status_nome,
+            data_ultima_manutencao: formatDate(bus.data_ultima_manutencao),
+            data_proxima_manutencao: formatDate(bus.data_proxima_manutencao)
+          };
+        });
       }
       
       setBuses(busesData);

--- a/web/src/pages/DriversPage.jsx
+++ b/web/src/pages/DriversPage.jsx
@@ -15,6 +15,7 @@ const tableHeaders = [
   { id: "cpf", label: "CPF", sortable: true },
   { id: "cnh_numero", label: "CNH", sortable: true },
   { id: "cnh_categoria", label: "Categoria", sortable: true },
+  { id: "cnh_validade", label: "Validade CNH", sortable: true },
   { id: "telefone", label: "Telefone", sortable: false },
   { id: "status_nome", label: "Status", sortable: true }
 ];
@@ -64,19 +65,32 @@ function Drivers({ pageFunctions }) {
         // Adaptar os dados do servidor para o formato esperado pelo frontend
         let driversData = [];
         if (response && response.data && Array.isArray(response.data)) {
-          driversData = response.data.map(driver => ({
-            id: driver.motorista_id,
-            nome: driver.nome,
-            cpf: formatCPF(driver.cpf),
-            cnh_numero: driver.cnh_numero,
-            cnh_categoria: driver.cnh_categoria,
-            cnh_validade: driver.cnh_validade,
-            telefone: formatPhoneNumber(driver.telefone),
-            email: driver.email,
-            data_admissao: driver.data_admissao,
-            status_motorista_id: driver.status_motorista_id,
-            status_nome: driver.status_nome || getStatusNome(driver.status_motorista_id)
-          }));
+          driversData = response.data.map(driver => {
+            // Função para formatar a data para DD/MM/AAAA
+            const formatDate = (dateString) => {
+              if (!dateString) return "N/A";
+              const date = new Date(dateString);
+              return date.toLocaleDateString('pt-BR', {
+                day: '2-digit',
+                month: '2-digit',
+                year: 'numeric'
+              });
+            };
+
+            return {
+              id: driver.motorista_id,
+              nome: driver.nome,
+              cpf: formatCPF(driver.cpf),
+              cnh_numero: driver.cnh_numero,
+              cnh_categoria: driver.cnh_categoria,
+              cnh_validade: formatDate(driver.cnh_validade),
+              telefone: formatPhoneNumber(driver.telefone),
+              email: driver.email,
+              data_admissao: formatDate(driver.data_admissao),
+              status_motorista_id: driver.status_motorista_id,
+              status_nome: driver.status_nome || getStatusNome(driver.status_motorista_id)
+            };
+          });
         }
         
         setDrivers(driversData);


### PR DESCRIPTION
Removed custom date formatters from detailConfigs and moved date formatting logic to BusesPage and DriversPage. Added formatted date columns for maintenance and CNH validity in the respective tables, ensuring dates are displayed in 'pt-BR' format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sortable columns for "Última Manutenção", "Próxima Manutenção", and "Quilometragem" in the buses table.
  * Added a sortable column for "Validade CNH" in the drivers table.

* **Style**
  * Dates for maintenance and driver license validity are now consistently displayed in the Brazilian date format (DD/MM/YYYY), with "N/A" shown for missing dates.

* **Refactor**
  * Removed custom formatting logic for overdue or expired dates in detail views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->