### PR TITLE
Auto-fill route origin and destination from selected stops

### DIFF
--- a/web/src/components/pageComponents/stopRoute/PainelControle.jsx
+++ b/web/src/components/pageComponents/stopRoute/PainelControle.jsx
@@ -23,7 +23,7 @@ function PainelControle({
 }) {
     const { calculateRouteStats } = useRouteWithStops();
     const stats = calculateRouteStats(pontosSelecionados);
-    const { formData, statusOptions, handleInputChange, validateForm } = useRouteForm(stats, initialData);
+    const { formData, statusOptions, handleInputChange, validateForm } = useRouteForm(stats, initialData, pontosSelecionados);
 
     // Função para mover pontos (drag and drop)
     const moveStop = useCallback((dragIndex, hoverIndex) => {

--- a/web/src/components/pageComponents/stopRoute/controlPainel/RouteForm.jsx
+++ b/web/src/components/pageComponents/stopRoute/controlPainel/RouteForm.jsx
@@ -148,7 +148,7 @@ function RouteForm({ formData, handleInputChange, statusOptions, instanceId }) {
                 id={`origem_descricao-${instanceId}`}
                 value={formData.origem_descricao}
                 onChange={(value) => handleInputChange('origem_descricao', value)}
-                placeholder="Ex: Terminal Centro"
+                placeholder="Será preenchido automaticamente com o primeiro ponto"
                 maxLength={255}
                 required
             />
@@ -159,7 +159,7 @@ function RouteForm({ formData, handleInputChange, statusOptions, instanceId }) {
                 id={`destino_descricao-${instanceId}`}
                 value={formData.destino_descricao}
                 onChange={(value) => handleInputChange('destino_descricao', value)}
-                placeholder="Ex: Terminal Bairro"
+                placeholder="Será preenchido automaticamente com o último ponto"
                 maxLength={255}
                 required
             />

--- a/web/src/components/pageComponents/stopRoute/controlPainel/useRouteForm.js
+++ b/web/src/components/pageComponents/stopRoute/controlPainel/useRouteForm.js
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import api from '@web/api/api';
 
-export function useRouteForm(stats, initialData = null) {
+export function useRouteForm(stats, initialData = null, pontosSelecionados = []) {
     const [formData, setFormData] = useState({
         nome: '',
         codigo_rota: '',
@@ -50,6 +50,41 @@ export function useRouteForm(stats, initialData = null) {
             }));
         }
     }, [stats.totalDistance, stats.estimatedTime]);
+
+    // Atualizar origem e destino automaticamente com base nos pontos selecionados
+    useEffect(() => {
+        if (pontosSelecionados && pontosSelecionados.length > 0) {
+            // Ordenar pontos por ordem para garantir que pegamos o primeiro e último corretos
+            const pontosOrdenados = [...pontosSelecionados].sort((a, b) => a.ordem - b.ordem);
+            
+            const primeiroNome = pontosOrdenados[0]?.nome || '';
+            const ultimoNome = pontosOrdenados[pontosOrdenados.length - 1]?.nome || '';
+            
+            // Só atualizar se os valores realmente mudaram para evitar renderizações desnecessárias
+            setFormData(prev => {
+                if (prev.origem_descricao !== primeiroNome || prev.destino_descricao !== ultimoNome) {
+                    return {
+                        ...prev,
+                        origem_descricao: primeiroNome,
+                        destino_descricao: ultimoNome
+                    };
+                }
+                return prev;
+            });
+        } else {
+            // Se não há pontos, limpar as descrições apenas se não estiverem vazias
+            setFormData(prev => {
+                if (prev.origem_descricao !== '' || prev.destino_descricao !== '') {
+                    return {
+                        ...prev,
+                        origem_descricao: '',
+                        destino_descricao: ''
+                    };
+                }
+                return prev;
+            });
+        }
+    }, [pontosSelecionados]);
 
     // Carregar opções de status da API
     useEffect(() => {


### PR DESCRIPTION
The form now automatically sets 'origem_descricao' and 'destino_descricao' based on the first and last selected stops, updating as the selection changes. Placeholders in the form fields were updated to reflect this behavior, improving user guidance and reducing manual input.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The origin and destination description fields in the route form are now automatically filled based on the first and last selected points.

* **Style**
  * Updated placeholder text for the origin and destination description fields to indicate they will be filled automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->