### PR TITLE
nooooosa

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -10,7 +10,8 @@
     "web": "expo start --web",
     "test": "jest --watchAll",
     "lint": "expo lint",
-    "build-apk": "eas build -p android --profile preview"
+    "build-apk": "eas build -p android --profile preview",
+    "setup-variables": "node ./scripts/configure-variables.js"
   },
   "jest": {
     "preset": "jest-expo"

--- a/mobile/scripts/configure-variables.js
+++ b/mobile/scripts/configure-variables.js
@@ -1,0 +1,42 @@
+const readline = require('readline');
+const os = require('os');
+const path = require('path');
+const { exec } = require('child_process');
+
+// Função para perguntar algo ao usuário
+function awaitInput(question) {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout
+  });
+  return new Promise(resolve => rl.question(question, ans => {
+    rl.close();
+    resolve(ans);
+  }));
+}
+
+async function main() {
+  let sdkPath = await awaitInput('Digite o caminho do Android SDK (deixe vazio para usar o padrão): ');
+  if (!sdkPath) {
+    sdkPath = path.join(os.homedir(), 'AppData', 'Local', 'Android', 'Sdk');
+  }
+  console.log('Caminho do Android SDK:', sdkPath);
+  // Comando para definir a variável de ambiente do usuário no Windows
+  const setxCmd = `setx ANDROID_HOME "${sdkPath}"`;
+  exec(setxCmd, (error, stdout, stderr) => {
+    if (error) {
+      console.error('Erro ao definir ANDROID_HOME:', error);
+    } else {
+      console.log('ANDROID_HOME configurado para:', sdkPath);
+      exec('echo %ANDROID_HOME%', (err, stdout) => {
+        if (err) {
+          console.error('Erro ao ler ANDROID_HOME do sistema:', err);
+        } else {
+          console.log('ANDROID_HOME (cmd):', stdout.trim());
+        }
+      });
+    }
+  });
+}
+
+main();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Added a setup helper for Windows that guides users to configure the Android SDK path and automatically sets ANDROID_HOME, simplifying first-time mobile build setup (with Portuguese prompts).
  * Introduced a new npm script to run this setup from the mobile project.
  * Kept the existing APK build script unchanged; no impact on app features or runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->