### PR TITLE
Comment out personal and address fields in passenger form

### DIFF
--- a/web/src/components/common/form/formConfigs.js
+++ b/web/src/components/common/form/formConfigs.js
@@ -9,104 +9,104 @@ import { formatters } from '../detail/detailConfigs';
 
 export const passengerFormConfig = {
   fields: [
-    {
-      name: 'nome',
-      type: 'text',
-      label: 'Nome',
-      labelIcon: 'bi bi-person-fill',
-      inputIcon: 'bi bi-person',
-      placeholder: 'Nome completo',
-      maxLength: 255,
-      required: true,
-      size: 'lg',
-      validator: (value) => {
-        return !value.trim() ? 'Nome é obrigatório' : null;
-      }
-    },
-    {
-      name: 'email',
-      type: 'email',
-      label: 'E-mail',
-      labelIcon: 'bi bi-envelope-fill',
-      inputIcon: 'bi bi-envelope',
-      placeholder: 'email@exemplo.com',
-      maxLength: 255,
-      required: true,
-      size: 'lg',
-      validator: (value) => {
-        if (!value.trim()) return 'E-mail é obrigatório';
-        if (!validateEmail(value)) return 'E-mail inválido';
-        return null;
-      }
-    },
-    {
-      name: 'cpf',
-      type: 'text',
-      label: 'CPF',
-      labelIcon: 'bi bi-card-text',
-      inputIcon: 'bi bi-123',
-      placeholder: '000.000.000-00',
-      maxLength: 14,
-      required: true,
-      size: 'lg',
-      formatter: (value) => formatCPF((value || '').toString()),
-      additionalProps: { 
-        autoComplete: 'new-password',
-        'data-form-type': 'other',
-        'data-lpignore': 'true',
-        'data-1p-ignore': 'true'
-      },
-      validator: (value) => {
-        if (!value.trim()) return 'CPF é obrigatório';
-        if (!validateCPF(value)) return 'CPF inválido';
-        return null;
-      }
-    },
-    {
-      name: 'telefone',
-      type: 'tel',
-      label: 'Telefone',
-      labelIcon: 'bi bi-telephone-fill',
-      inputIcon: 'bi bi-telephone',
-      placeholder: '(00) 00000-0000',
-      maxLength: 15,
-      size: 'lg',
-      formatter: (value) => formatPhoneNumber((value || '').toString()),
-      validator: (value) => {
-        if (value && !validatePhoneNumber(value)) return 'Formato: (00) 00000-0000';
-        return null;
-      }
-    },
-    {
-      name: 'data_nascimento',
-      type: 'date',
-      label: 'Data de Nascimento',
-      labelIcon: 'bi bi-calendar-plus-fill',
-      inputIcon: 'bi bi-calendar-plus',
-      placeholder: 'Data de nascimento',
-      size: 'lg',
-      additionalProps: { 
-        max: new Date().toISOString().split('T')[0],
-        autoComplete: 'new-password',
-        'data-form-type': 'other',
-        'data-lpignore': 'true',
-        'data-1p-ignore': 'true'
-      },
-      reverseTransform: reverseTransformDate,
-      validator: validateBirthDate
-    },
-    {
-      name: 'pcd',
-      type: 'checkbox',
-      label: 'Pessoa com Deficiência (PCD)',
-      labelIcon: 'bi bi-universal-access',
-      inputIcon: 'bi bi-universal-access',
-      size: 'lg',
-      className: 'pcd-checkbox',
-      additionalProps: { 
-        'data-form-type': 'other'
-      }
-    },
+    // {
+    //   name: 'nome',
+    //   type: 'text',
+    //   label: 'Nome',
+    //   labelIcon: 'bi bi-person-fill',
+    //   inputIcon: 'bi bi-person',
+    //   placeholder: 'Nome completo',
+    //   maxLength: 255,
+    //   required: true,
+    //   size: 'lg',
+    //   validator: (value) => {
+    //     return !value.trim() ? 'Nome é obrigatório' : null;
+    //   }
+    // },
+    // {
+    //   name: 'email',
+    //   type: 'email',
+    //   label: 'E-mail',
+    //   labelIcon: 'bi bi-envelope-fill',
+    //   inputIcon: 'bi bi-envelope',
+    //   placeholder: 'email@exemplo.com',
+    //   maxLength: 255,
+    //   required: true,
+    //   size: 'lg',
+    //   validator: (value) => {
+    //     if (!value.trim()) return 'E-mail é obrigatório';
+    //     if (!validateEmail(value)) return 'E-mail inválido';
+    //     return null;
+    //   }
+    // },
+    // {
+    //   name: 'cpf',
+    //   type: 'text',
+    //   label: 'CPF',
+    //   labelIcon: 'bi bi-card-text',
+    //   inputIcon: 'bi bi-123',
+    //   placeholder: '000.000.000-00',
+    //   maxLength: 14,
+    //   required: true,
+    //   size: 'lg',
+    //   formatter: (value) => formatCPF((value || '').toString()),
+    //   additionalProps: { 
+    //     autoComplete: 'new-password',
+    //     'data-form-type': 'other',
+    //     'data-lpignore': 'true',
+    //     'data-1p-ignore': 'true'
+    //   },
+    //   validator: (value) => {
+    //     if (!value.trim()) return 'CPF é obrigatório';
+    //     if (!validateCPF(value)) return 'CPF inválido';
+    //     return null;
+    //   }
+    // },
+    // {
+    //   name: 'telefone',
+    //   type: 'tel',
+    //   label: 'Telefone',
+    //   labelIcon: 'bi bi-telephone-fill',
+    //   inputIcon: 'bi bi-telephone',
+    //   placeholder: '(00) 00000-0000',
+    //   maxLength: 15,
+    //   size: 'lg',
+    //   formatter: (value) => formatPhoneNumber((value || '').toString()),
+    //   validator: (value) => {
+    //     if (value && !validatePhoneNumber(value)) return 'Formato: (00) 00000-0000';
+    //     return null;
+    //   }
+    // },
+    // {
+    //   name: 'data_nascimento',
+    //   type: 'date',
+    //   label: 'Data de Nascimento',
+    //   labelIcon: 'bi bi-calendar-plus-fill',
+    //   inputIcon: 'bi bi-calendar-plus',
+    //   placeholder: 'Data de nascimento',
+    //   size: 'lg',
+    //   additionalProps: { 
+    //     max: new Date().toISOString().split('T')[0],
+    //     autoComplete: 'new-password',
+    //     'data-form-type': 'other',
+    //     'data-lpignore': 'true',
+    //     'data-1p-ignore': 'true'
+    //   },
+    //   reverseTransform: reverseTransformDate,
+    //   validator: validateBirthDate
+    // },
+    // {
+    //   name: 'pcd',
+    //   type: 'checkbox',
+    //   label: 'Pessoa com Deficiência (PCD)',
+    //   labelIcon: 'bi bi-universal-access',
+    //   inputIcon: 'bi bi-universal-access',
+    //   size: 'lg',
+    //   className: 'pcd-checkbox',
+    //   additionalProps: { 
+    //     'data-form-type': 'other'
+    //   }
+    // },
     {
       name: 'tipo_passageiro',
       alternativeKey: 'tipo_passageiro_id',
@@ -130,113 +130,113 @@ export const passengerFormConfig = {
       }
     },
     // Seção de Endereço - CEP primeiro para preenchimento automático
-    {
-      name: 'cep',
-      type: 'text',
-      label: 'CEP',
-      labelIcon: 'bi bi-mailbox',
-      inputIcon: 'bi bi-envelope',
-      placeholder: '00000-000',
-      maxLength: 9,
-      required: true,
-      size: 'lg',
-      formatter: (value) => formatCEP((value || '').toString()),
-      validator: (value) => {
-        if (!value.trim()) return 'CEP é obrigatório';
-        if (!validateCEP(value)) return 'CEP deve ter o formato 00000-000';
-        return null;
-      },
-      onBlur: 'handleCepBlur', // Evento para buscar dados do CEP
-      helpText: 'Digite o CEP para preenchimento automático do endereço'
-    },
-    {
-      name: 'logradouro',
-      type: 'text',
-      label: 'Logradouro',
-      labelIcon: 'bi bi-house-fill',
-      inputIcon: 'bi bi-geo',
-      placeholder: 'Nome da rua/avenida',
-      maxLength: 255,
-      required: true,
-      size: 'lg',
-      validator: (value) => {
-        if (!value.trim()) return 'Logradouro é obrigatório';
-        return null;
-      }
-    },
-    {
-      name: 'numero_endereco',
-      type: 'text',
-      label: 'Número',
-      labelIcon: 'bi bi-123',
-      inputIcon: 'bi bi-hash',
-      placeholder: 'Número do endereço',
-      maxLength: 20,
-      required: true,
-      size: 'lg',
-      validator: (value) => {
-        if (!value.trim()) return 'Número é obrigatório';
-        return null;
-      }
-    },
-    {
-      name: 'complemento_endereco',
-      type: 'text',
-      label: 'Complemento',
-      labelIcon: 'bi bi-house-door',
-      inputIcon: 'bi bi-plus-circle',
-      placeholder: 'Apartamento, bloco, etc.',
-      maxLength: 100,
-      size: 'lg'
-    },
-    {
-      name: 'bairro',
-      type: 'text',
-      label: 'Bairro',
-      labelIcon: 'bi bi-building',
-      inputIcon: 'bi bi-buildings',
-      placeholder: 'Nome do bairro',
-      maxLength: 100,
-      required: true,
-      size: 'lg',
-      validator: (value) => {
-        if (!value.trim()) return 'Bairro é obrigatório';
-        return null;
-      }
-    },
-    {
-      name: 'cidade',
-      type: 'text',
-      label: 'Cidade',
-      labelIcon: 'bi bi-geo-alt',
-      inputIcon: 'bi bi-building',
-      placeholder: 'Nome da cidade',
-      maxLength: 100,
-      required: true,
-      size: 'lg',
-      validator: (value) => {
-        if (!value.trim()) return 'Cidade é obrigatória';
-        return null;
-      }
-    },
-    {
-      name: 'uf',
-      type: 'select',
-      label: 'UF',
-      labelIcon: 'bi bi-flag',
-      inputIcon: 'bi bi-flag',
-      placeholder: 'Selecione o estado',
-      required: true,
-      size: 'lg',
-      defaultOptions: BRAZILIAN_STATES,
-      optionValue: 'value',
-      optionLabel: 'label',
-      validator: (value) => {
-        if (!value) return 'Estado é obrigatório';
-        if (!isValidUF(value)) return 'Estado inválido';
-        return null;
-      }
-    },
+    // {
+    //   name: 'cep',
+    //   type: 'text',
+    //   label: 'CEP',
+    //   labelIcon: 'bi bi-mailbox',
+    //   inputIcon: 'bi bi-envelope',
+    //   placeholder: '00000-000',
+    //   maxLength: 9,
+    //   required: true,
+    //   size: 'lg',
+    //   formatter: (value) => formatCEP((value || '').toString()),
+    //   validator: (value) => {
+    //     if (!value.trim()) return 'CEP é obrigatório';
+    //     if (!validateCEP(value)) return 'CEP deve ter o formato 00000-000';
+    //     return null;
+    //   },
+    //   onBlur: 'handleCepBlur', // Evento para buscar dados do CEP
+    //   helpText: 'Digite o CEP para preenchimento automático do endereço'
+    // },
+    // {
+    //   name: 'logradouro',
+    //   type: 'text',
+    //   label: 'Logradouro',
+    //   labelIcon: 'bi bi-house-fill',
+    //   inputIcon: 'bi bi-geo',
+    //   placeholder: 'Nome da rua/avenida',
+    //   maxLength: 255,
+    //   required: true,
+    //   size: 'lg',
+    //   validator: (value) => {
+    //     if (!value.trim()) return 'Logradouro é obrigatório';
+    //     return null;
+    //   }
+    // },
+    // {
+    //   name: 'numero_endereco',
+    //   type: 'text',
+    //   label: 'Número',
+    //   labelIcon: 'bi bi-123',
+    //   inputIcon: 'bi bi-hash',
+    //   placeholder: 'Número do endereço',
+    //   maxLength: 20,
+    //   required: true,
+    //   size: 'lg',
+    //   validator: (value) => {
+    //     if (!value.trim()) return 'Número é obrigatório';
+    //     return null;
+    //   }
+    // },
+    // {
+    //   name: 'complemento_endereco',
+    //   type: 'text',
+    //   label: 'Complemento',
+    //   labelIcon: 'bi bi-house-door',
+    //   inputIcon: 'bi bi-plus-circle',
+    //   placeholder: 'Apartamento, bloco, etc.',
+    //   maxLength: 100,
+    //   size: 'lg'
+    // },
+    // {
+    //   name: 'bairro',
+    //   type: 'text',
+    //   label: 'Bairro',
+    //   labelIcon: 'bi bi-building',
+    //   inputIcon: 'bi bi-buildings',
+    //   placeholder: 'Nome do bairro',
+    //   maxLength: 100,
+    //   required: true,
+    //   size: 'lg',
+    //   validator: (value) => {
+    //     if (!value.trim()) return 'Bairro é obrigatório';
+    //     return null;
+    //   }
+    // },
+    // {
+    //   name: 'cidade',
+    //   type: 'text',
+    //   label: 'Cidade',
+    //   labelIcon: 'bi bi-geo-alt',
+    //   inputIcon: 'bi bi-building',
+    //   placeholder: 'Nome da cidade',
+    //   maxLength: 100,
+    //   required: true,
+    //   size: 'lg',
+    //   validator: (value) => {
+    //     if (!value.trim()) return 'Cidade é obrigatória';
+    //     return null;
+    //   }
+    // },
+    // {
+    //   name: 'uf',
+    //   type: 'select',
+    //   label: 'UF',
+    //   labelIcon: 'bi bi-flag',
+    //   inputIcon: 'bi bi-flag',
+    //   placeholder: 'Selecione o estado',
+    //   required: true,
+    //   size: 'lg',
+    //   defaultOptions: BRAZILIAN_STATES,
+    //   optionValue: 'value',
+    //   optionLabel: 'label',
+    //   validator: (value) => {
+    //     if (!value) return 'Estado é obrigatório';
+    //     if (!isValidUF(value)) return 'Estado inválido';
+    //     return null;
+    //   }
+    // },
     // Relacionamentos
     {
       name: 'rota_id',

--- a/web/src/components/core/feedback/PopUpComponent.jsx
+++ b/web/src/components/core/feedback/PopUpComponent.jsx
@@ -19,6 +19,33 @@ const styles = {
     overflowY: 'auto', // Permite scroll vertical se necessário
     outline: 0,
   },
+  modalContent: {
+    display: 'flex',
+    flexDirection: 'column',
+    height: 'auto',
+    maxHeight: '90vh', // Limita altura máxima para não ocupar toda a tela
+    width: '100%', // Garante que o modal use toda largura disponível
+  },
+  modalBody: {
+    flex: 1,
+    overflow: 'auto',
+    padding: '1rem',
+    minHeight: '200px', // Altura mínima para garantir espaço útil
+    width: '100%', // Força o conteúdo a usar toda largura
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  contentWrapper: {
+    width: '100%',
+    height: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+    // Força todos os elementos filhos a ocuparem todo o espaço
+    '& > *': {
+      width: '100%',
+      flex: 1,
+    },
+  },
 };
 
 /**
@@ -125,7 +152,10 @@ const PopUpComponent = memo(forwardRef((props, ref) => {
     >
       {/* Container do modal - previne o fechamento ao clicar dentro */}
       <div className="modal-dialog modal-dialog-centered d-flex justify-content-center" onClick={(e) => e.stopPropagation()}>
-        <div className="modal-content w-auto">
+        <div 
+          className="modal-content" 
+          style={styles.modalContent}
+        >
           {/* Cabeçalho do modal */}
           <div className="modal-header">
             {/* Título opcional */}
@@ -134,8 +164,22 @@ const PopUpComponent = memo(forwardRef((props, ref) => {
             <button type="button" className="btn-close" aria-label="Close" onClick={hide}></button>
           </div>
           {/* Corpo do modal onde o conteúdo é renderizado */}
-          <div className="modal-body">
-            {ContentComponent && <ContentComponent {...componentProps} />}
+          <div className="modal-body" style={styles.modalBody}>
+            <div 
+              style={{
+                ...styles.contentWrapper,
+                // Estilos adicionais para garantir ocupação total do espaço
+                minHeight: '100%',
+                justifyContent: 'stretch',
+                alignItems: 'stretch',
+              }}
+            >
+              {ContentComponent && (
+                <div style={{ width: '100%', height: '100%', display: 'flex', flexDirection: 'column' }}>
+                  <ContentComponent {...componentProps} />
+                </div>
+              )}
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Commented out the personal (nome, email, cpf, telefone, data_nascimento, pcd) and address (cep, logradouro, numero_endereco, complemento_endereco, bairro, cidade, uf) fields in passengerFormConfig, leaving only tipo_passageiro and rota_id. Also improved PopUpComponent modal layout with new styles for better content stretching and scrolling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Streamlined the passenger form to include only passenger type and route/stop fields, removing personal and address inputs for a faster, simpler flow.
- Style
  - Updated modal layout for improved readability and responsiveness: full-width, constrained height with scrollable body, and content that stretches consistently within the modal.
  - Preserves overlay click confirmation behavior while refining internal structure for more reliable spacing and sizing across content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->